### PR TITLE
Updated distech.html

### DIFF
--- a/distech.html
+++ b/distech.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Group G | Disruptive Technologies</title>
-    <link rel="stylesheet" href="homepage.css">
+    <link rel="stylesheet" href="styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,200..1000;1,200..1000&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@100..900&display=swap" rel="stylesheet">
 </head>
@@ -15,7 +15,7 @@
      <nav>
         <div class="menu-bar">
             <div class="logo">
-                <img class="logo-pic" src="images/logo.png">
+                <img class="logo-pic" src="homepage-images/logo.png">
             </div>
             <ul>
                 <li><a href="homepage.html">Home</a></li>
@@ -36,17 +36,21 @@
   </header>
 
     <main>
-      <!-- ▮▮ TITLE IMAGE ▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮ -->
-      <section class="title-image"></section>
-      <!-- ▮▮ BACK BUTTON ▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮ -->
+      <!-- ▮▮ TITLE BANNER ▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮ -->
+      <div class="banner-area">
+        <div class="banner-image-distech"> <!--Banner Image specifically for distech page-->
+          <div class="banner-text">
+            <h3 class="page-title">DISRUPTIVE TECHNOLOGIES</h3>
+          </div>
+        </div>
+      </div>
 
-      <section class="back"></section>
       <!-- ▮▮ MAIN INFORMATION ▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮ -->
 
-      <section class="main-block">
+      <div class="content-area">
         <div class="distech-info">
           <!-- TITLE SECTION -->
-          <h1>Disruptie Technology</h1>
+          <h1>Disruptive Technology</h1>
           <!-- SECTION 1: What is Disruptive Tech? -->
           <h2>What is Disruptive Technology?</h2>
           <p>
@@ -132,7 +136,7 @@
             That’s a very good example of a sustaining technology.
           </p>
         </div>
-      </section>
+      </div>
     </main>
 
     <footer></footer>


### PR DESCRIPTION
I mainly based these edits on the DISRUPTIVE TECHNOLOGIES PAGE. 


SUMMARY OF GENERAL EDITS:

- Body - margin - changed to 0 
- Main - max width - changed to 0 
- Padding - changed to 0  ( ^ changed this to accommodate the banner since it was also affecting the banner and nav bar. But to compensate for the lost margins and padding, I encased the content into their own sections and added back the edits there)



THREE MAIN AREAS OF EACH PAGE (distech.html, grab.html, outcomes.html)
1. <nav> -nav bar
2. <banner-area> - banner images and static scrolling 
3. <content-area> - main text and content (this is where I re-added the margins and padding values )

(I edited the rest of the pages codes as well to align with these changes! Do mention if ever they pose an issue to the existing code — since I only based it off of distech.html) 

- Edits to Banner Images: 
    - Added images for each section (added to the ‘homepage-images’ folder) - banner-image-distech - banner-image-grab

Note: I linked the images to the site! It should work now and images should load for every device (double check)  (homepage-images/picture.jpg) <—— changed that in each url value

- Edits to Content Area (Content block) 
    - Created a rounded container for the content 
    - Justified + centered text 
    - Added box shadow (black)